### PR TITLE
Added Method to ask a bucket for the next bucket start time

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "arrowParens": "always",
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 180,
+  "tabWidth": 2
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic8bot/timebucket",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/bucket-size.ts
+++ b/src/bucket-size.ts
@@ -35,7 +35,7 @@ export class BucketSize {
   }
 
   public parse(spec: string) {
-    const match = String(spec).match(BucketSize.regex)
+    const match = spec.match(BucketSize.regex)
     if (!match) throw new Error('invalid bucket size spec: ' + spec)
     if (!match[1]) match[1] = '1'
 
@@ -53,6 +53,10 @@ export class BucketSize {
 
   public toString() {
     return this.value === 1 ? this.granularity : this.spec
+  }
+
+  public equals(other: BucketSize) {
+    return this.value == other.value && this.granularity == other.granularity
   }
 
   public pack() {

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -38,14 +38,23 @@ export class Bucket {
     return this.size.toMilliseconds() * this.value
   }
 
+  public getEndOfBucketMS() {
+    return this.toMilliseconds() + this.size.toMilliseconds()
+  }
+
   public toDate() {
     return new Date(this.toMilliseconds())
   }
 
+  public getEndOfBucketDate() {
+    return new Date(this.getEndOfBucketMS())
+  }
+
   public resize(spec) {
     const size = new BucketSize(spec)
-    if (size.granularity === this.size.granularity && size.value === this.size.value) return this
-
+    if (this.size.equals(size)) {
+      return this
+    }
     const value = Math.floor(this.toMilliseconds() / size.toMilliseconds())
     return new Bucket(size.spec, value)
   }


### PR DESCRIPTION
I was coding around the period publishing in the bot, because this depending on active trades. 
if you are trading in a market with low volume you may miss periods because of that, or they are not aligned with the markets periods. 
Due this i recognized that there is no way to ask a bucket, when its ending.
This PR will add a method to query the buckets end.